### PR TITLE
Verify Region Data Exists

### DIFF
--- a/lib/rubillow/models/zestimateable.rb
+++ b/lib/rubillow/models/zestimateable.rb
@@ -63,16 +63,18 @@ module Rubillow
           @change_duration = tmp.value
         end
         @percentile = xml.xpath('//zestimate/percentile').text
-        
-        @region = xml.xpath('//localRealEstate/region').attribute('name').value
-        @region_id = xml.xpath('//localRealEstate/region').attribute('id').value
-        @region_type = xml.xpath('//localRealEstate/region').attribute('type').value
-      
-        @local_real_estate = {
-          :overview => xml.xpath('//localRealEstate/region/links/overview').text,
-          :for_sale_by_owner => xml.xpath('//localRealEstate/region/links/forSaleByOwner').text,
-          :for_sale => xml.xpath('//localRealEstate/region/links/forSale').text,
-        }
+
+        if xml.at_xpath('//localRealEstate/region')
+          @region = xml.xpath('//localRealEstate/region').attribute('name').value
+          @region_id = xml.xpath('//localRealEstate/region').attribute('id').value
+          @region_type = xml.xpath('//localRealEstate/region').attribute('type').value
+
+          @local_real_estate = {
+            :overview => xml.xpath('//localRealEstate/region/links/overview').text,
+            :for_sale_by_owner => xml.xpath('//localRealEstate/region/links/forSaleByOwner').text,
+            :for_sale => xml.xpath('//localRealEstate/region/links/forSale').text,
+          }
+        end
       end
     end
   end

--- a/spec/rubillow/models/search_result_spec.rb
+++ b/spec/rubillow/models/search_result_spec.rb
@@ -65,4 +65,30 @@ describe Rubillow::Models::SearchResult do
     data.region_type.should == "neighborhood"
     data.region_id.should == "271856"
   end
+
+  it "populates the results from GetZestimate with missing region data" do
+    data = Rubillow::Models::SearchResult.new(get_xml('get_zestimate_missing_region.xml'))
+
+    data.zpid.should == '78264249'
+    data.links.count.should == 4
+    data.links[:homedetails].should == "http://www.zillow.com/homedetails/8663-Orchard-Loop-Rd-NE-Leland-NC-28451/78264249_zpid/"
+    data.links[:graphsanddata].should == "http://www.zillow.com/homedetails/8663-Orchard-Loop-Rd-NE-Leland-NC-28451/78264249_zpid/#charts-and-data"
+    data.links[:mapthishome].should == "http://www.zillow.com/homes/78264249_zpid/"
+    data.links[:comparables].should == "http://www.zillow.com/homes/comps/78264249_zpid/"
+    data.address[:street].should == "8663 Orchard Loop Rd NE"
+    data.address[:city].should == "Leland"
+    data.address[:state].should == "NC"
+    data.address[:zipcode].should == "28451"
+    data.address[:latitude].should == "34.217408"
+    data.address[:longitude].should == "-78.054412"
+    data.price.should == "136518"
+    data.percentile.should == "58"
+    data.last_updated.strftime("%m/%d/%Y").should == "12/27/2012"
+    data.valuation_range[:low].should == "23208"
+    data.valuation_range[:high].should == "203412"
+    data.change.should == "-1299"
+    data.change_duration.should == "30"
+    data.local_real_estate.should == nil
+    data.region.should == nil
+  end
 end

--- a/spec/xml/get_zestimate_missing_region.xml
+++ b/spec/xml/get_zestimate_missing_region.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Zestimate:zestimate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:Zestimate="http://www.zillow.com/static/xsd/Zestimate.xsd" xsi:schemaLocation="http://www.zillow.com/static/xsd/Zestimate.xsd http://www.zillowstatic.com/vstatic/4f6d65a3e1e76db2baf166972ee9ef71/static/xsd/Zestimate.xsd">
+  <request>
+    <zpid>78264249</zpid>
+  </request>
+  <message>
+    <text>Request successfully processed</text>
+    <code>0</code>
+  </message>
+  <response>
+    <zpid>78264249</zpid>
+    <links>
+      <homedetails>http://www.zillow.com/homedetails/8663-Orchard-Loop-Rd-NE-Leland-NC-28451/78264249_zpid/</homedetails>
+      <graphsanddata>http://www.zillow.com/homedetails/8663-Orchard-Loop-Rd-NE-Leland-NC-28451/78264249_zpid/#charts-and-data</graphsanddata>
+      <mapthishome>http://www.zillow.com/homes/78264249_zpid/</mapthishome>
+      <comparables>http://www.zillow.com/homes/comps/78264249_zpid/</comparables>
+    </links>
+    <address>
+      <street>8663 Orchard Loop Rd NE</street>
+      <zipcode>28451</zipcode>
+      <city>Leland</city>
+      <state>NC</state>
+      <latitude>34.217408</latitude>
+      <longitude>-78.054412</longitude>
+    </address>
+    <zestimate>
+      <amount currency="USD">136518</amount>
+      <last-updated>12/27/2012</last-updated>
+      <oneWeekChange deprecated="true"></oneWeekChange>
+      <valueChange duration="30" currency="USD">-1299</valueChange>
+      <valuationRange>
+        <low currency="USD">23208</low>
+        <high currency="USD">203412</high>
+      </valuationRange>
+      <percentile>58</percentile>
+    </zestimate>
+    <localRealEstate></localRealEstate>
+    <regions>
+      <zipcode-id>69961</zipcode-id>
+      <city-id></city-id>
+      <county-id>2640</county-id>
+      <state-id>36</state-id>
+    </regions>
+  </response>
+</Zestimate:zestimate>
+<!-- H:001  T:15ms  S:790  R:Fri Dec 28 20:59:48 PST 2012  B:3.0.177752.20121228113358693comp_rel_a.177752.20121228113743311comp_rel_a -->


### PR DESCRIPTION
In some rare cases the region data for a property is empty and would cause the rubillow to throw a missing method error when attempting to read the region attributes. This fix verifies the region data exists before attempting to write it to the model.
