### PR TITLE
Fix common scenarios where xml nodes are not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6 / 2013-04-10
+  
+  * Fix RentZestimate bug when valueChange doesn't have a duration.
+
 ## 0.0.5 / 2013-01-12
 
   * Include RentZestimate if available

--- a/lib/rubillow/helpers/xml_parsing_helper.rb
+++ b/lib/rubillow/helpers/xml_parsing_helper.rb
@@ -1,0 +1,15 @@
+# Helper methods for parsing XML.
+module XmlParsingHelper
+  # @param path [String] Xpath query to find the node in XML.
+  # @param attribute [Symbol] Attribute on the node to call and return as the value.
+  # @param xml [Nokogiri::XML] A nokogiri parser object to call #xpath.
+  # @param nil_value (optional) A value to return if the attribute on the node
+  # is nil or if the node is not present.
+  #
+  # @return [String] Value from an attribute of an xpath node, if present.
+  # If the node is not present, return nil or nil_value if specified.
+  def xpath_if_present(path, attribute, xml, nil_value = nil)
+    text = xml.xpath(path).first.send(attribute) unless xml.xpath(path).empty?
+    text ||= nil_value
+  end
+end

--- a/lib/rubillow/models.rb
+++ b/lib/rubillow/models.rb
@@ -1,10 +1,13 @@
 require "nokogiri"
+require "rubillow/helpers/xml_parsing_helper"
 
 module Rubillow
   # Sub module for returned and parsed web service data
   module Models
     # Base class for data models
     class Base
+      include XmlParsingHelper
+
       # @return [String] the raw XML content from the service
       attr_accessor :xml
       

--- a/lib/rubillow/models/deep_search_result.rb
+++ b/lib/rubillow/models/deep_search_result.rb
@@ -3,6 +3,7 @@ module Rubillow
     # Get a property's information with deeper data.
     class DeepSearchResult < SearchResult    
       include PropertyBasics
+      include XmlParsingHelper
       
       # @return [String] FIPS county code. See {http://www.itl.nist.gov/fipspubs/fip6-4.htm}.
       attr_accessor :fips_county
@@ -31,15 +32,14 @@ module Rubillow
         return if !success?
         
         extract_property_basics(@parser)
-        @fips_county = ""
-        @fips_county = @parser.xpath('//FIPScounty').first.text unless @parser.xpath('//FIPScounty').empty?
-        @tax_assessment_year = @parser.xpath('//taxAssessmentYear').first.text
-        @tax_assessment = @parser.xpath('//taxAssessment').first.text
-        @year_built = @parser.xpath('//yearBuilt').first.text
-        if tmp = @parser.xpath('//lastSoldDate').first.text and tmp.strip.length > 0
+        @fips_county = xpath_if_present('//FIPScounty', :text, @parser, "")
+        @tax_assessment_year = xpath_if_present('//taxAssessmentYear', :text, @parser)
+        @tax_assessment = xpath_if_present('//taxAssessment', :text, @parser)
+        @year_built = xpath_if_present('//yearBuilt', :text, @parser)
+        if tmp = xpath_if_present('//lastSoldDate', :text, @parser) and tmp.strip.length > 0
           @last_sold_date = Date.strptime(tmp, "%m/%d/%Y")
         end
-        @last_sold_price = @parser.xpath('//lastSoldPrice').first.text
+        @last_sold_price = xpath_if_present('//lastSoldPrice', :text, @parser)
       end
     end
   end

--- a/lib/rubillow/models/property_basics.rb
+++ b/lib/rubillow/models/property_basics.rb
@@ -24,13 +24,12 @@ module Rubillow
       
       # @private
       def extract_property_basics(xml)
-        @use_code = ""
-        @use_code = xml.xpath('//useCode').first.text unless xml.xpath('//useCode').empty?
-        @lot_size_square_feet = xml.xpath('//lotSizeSqFt').text
-        @finished_square_feet = xml.xpath('//finishedSqFt').first.text
-        @bathrooms = xml.xpath('//bathrooms').first.text
-        @bedrooms = xml.xpath('//bedrooms').first.text
-        @total_rooms = xml.xpath('//totalRooms').text
+        @use_code = xpath_if_present('//useCode', :text, xml, "")
+        @lot_size_square_feet = xpath_if_present('//lotSizeSqFt', :text, xml, "")
+        @finished_square_feet = xpath_if_present('//finishedSqFt', :text, xml, "")
+        @bathrooms = xpath_if_present('//bathrooms', :text, xml, "")
+        @bedrooms = xpath_if_present('//bedrooms', :text, xml, "")
+        @total_rooms = xpath_if_present('//totalRooms', :text, xml, "")
       end
     end
   end

--- a/lib/rubillow/models/zestimateable.rb
+++ b/lib/rubillow/models/zestimateable.rb
@@ -67,7 +67,7 @@ module Rubillow
             :price => xml.xpath('//rentzestimate/amount').first.text,
             :last_updated => xml.xpath('//rentzestimate/last-updated').first.text,
             :value_change => xml.xpath('//rentzestimate/valueChange').first.text,
-            :value_duration => xml.xpath('//rentzestimate').first.xpath('//valueChange').attr('duration').value.chomp,
+            :value_duration => xml.xpath('//rentzestimate').first.xpath("//valueChange").first.attr("duration").chomp,
             :valuation_range => {
               :low => xml.xpath('//rentzestimate/valuationRange/low').first.text,
               :high => xml.xpath('//rentzestimate/valuationRange/high').first.text

--- a/lib/rubillow/version.rb
+++ b/lib/rubillow/version.rb
@@ -1,4 +1,4 @@
 module Rubillow
   # @private
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/rubillow/models/deep_search_results_spec.rb
+++ b/spec/rubillow/models/deep_search_results_spec.rb
@@ -87,4 +87,10 @@ describe Rubillow::Models::DeepSearchResult do
     data.last_sold_price.should == "186000"
     data.use_code.should == "Condominium"
   end
+
+  it "doesn't raise an error when data is missing" do
+    lambda {
+      Rubillow::Models::DeepSearchResult.new(get_xml("get_deep_search_results_missing_data.xml"))
+    }.should_not raise_error
+  end
 end

--- a/spec/rubillow/models/search_result_spec.rb
+++ b/spec/rubillow/models/search_result_spec.rb
@@ -97,4 +97,12 @@ describe Rubillow::Models::SearchResult do
     data.local_real_estate.should == nil
     data.region.should == nil
   end
+
+  it "populates the results from GetZestimate with missing valueDuration data" do
+    data = Rubillow::Models::SearchResult.new(get_xml('get_zestimate_missing_value_duration.xml'))
+    
+    data.zpid.should == '29366758'
+    data.rent_zestimate.should be_a Hash
+    data.rent_zestimate[:value_duration].should be == '30' 
+  end
 end

--- a/spec/xml/get_deep_search_results_missing_data.xml
+++ b/spec/xml/get_deep_search_results_missing_data.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SearchResults:searchresults xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.zillow.com/static/xsd/SearchResults.xsd http://www.zillowstatic.com/vstatic/ff767ff8bf412f0cf22b5c412ec1cc5a/static/xsd/SearchResults.xsd" xmlns:SearchResults="http://www.zillow.com/static/xsd/SearchResults.xsd">
+  <request>
+    <address>23366-Torrey-St</address>
+    <citystatezip>Armada MI 48005</citystatezip>
+  </request>
+  <message>
+    <text>Request successfully processed</text>
+    <code>0</code>
+  </message>
+  <response>
+    <results>
+      <result>
+        <zpid>83624854</zpid>
+        <links>
+          <homedetails>http://www.zillow.com/homedetails/23366-Torrey-St-Armada-MI-48005/83624854_zpid/</homedetails>
+          <graphsanddata>http://www.zillow.com/homedetails/23366-Torrey-St-Armada-MI-48005/83624854_zpid/#charts-and-data</graphsanddata>
+          <mapthishome>http://www.zillow.com/homes/83624854_zpid/</mapthishome>
+          <comparables>http://www.zillow.com/homes/comps/83624854_zpid/</comparables>
+        </links>
+        <address>
+          <street>23366 Torrey St</street>
+          <zipcode>48005</zipcode>
+          <city>Armada</city>
+          <state>MI</state>
+          <latitude>42.842281</latitude>
+          <longitude>-82.88019</longitude>
+        </address>
+        <FIPScounty>26099</FIPScounty>
+        <useCode>SingleFamily</useCode>
+        <taxAssessmentYear>2011</taxAssessmentYear>
+        <taxAssessment>100376.0</taxAssessment>
+        <lotSizeSqFt>14810</lotSizeSqFt>
+        <zestimate>
+          <amount currency="USD">89301</amount>
+          <last-updated>04/09/2013</last-updated>
+          <oneWeekChange deprecated="true"></oneWeekChange>
+          <valueChange duration="30" currency="USD">-1566</valueChange>
+          <valuationRange>
+            <low currency="USD">74120</low>
+            <high currency="USD">108947</high>
+          </valuationRange>
+          <percentile>0</percentile>
+        </zestimate>
+        <localRealEstate>
+          <region id="50765" type="city" name="Armada">
+            <links>
+              <overview>http://www.zillow.com/local-info/MI-Armada/r_50765/</overview>
+              <forSaleByOwner>http://www.zillow.com/armada-mi/fsbo/</forSaleByOwner>
+              <forSale>http://www.zillow.com/armada-mi/</forSale>
+            </links>
+          </region>
+        </localRealEstate>
+      </result>
+    </results>
+  </response>
+</SearchResults:searchresults>
+<!-- H:003  T:32ms  S:983  R:Wed Apr 10 13:55:59 PDT 2013  B:3.0.189437.20130408124808855-comp_rel_b.189437.20130408124954685-comp_rel_b -->

--- a/spec/xml/get_zestimate_missing_value_duration.xml
+++ b/spec/xml/get_zestimate_missing_value_duration.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Zestimate:zestimate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:Zestimate="http://www.zillow.com/static/xsd/Zestimate.xsd" xsi:schemaLocation="http://www.zillow.com/static/xsd/Zestimate.xsd http://www.zillowstatic.com/vstatic/ff767ff8bf412f0cf22b5c412ec1cc5a/static/xsd/Zestimate.xsd">
+  <request>
+    <zpid>29366758</zpid>
+  </request>
+  <message>
+    <text>Request successfully processed</text>
+    <code>0</code>
+  </message>
+  <response>
+    <zpid>29366758</zpid>
+    <links>
+      <homedetails>http://www.zillow.com/homedetails/7500-Blue-Beach-Cv-Austin-TX-78759/29366758_zpid/</homedetails>
+      <graphsanddata>http://www.zillow.com/homedetails/7500-Blue-Beach-Cv-Austin-TX-78759/29366758_zpid/#charts-and-data</graphsanddata>
+      <mapthishome>http://www.zillow.com/homes/29366758_zpid/</mapthishome>
+      <comparables>http://www.zillow.com/homes/comps/29366758_zpid/</comparables>
+    </links>
+    <address>
+      <street>7500 Blue Beach Cv</street>
+      <zipcode>78759</zipcode>
+      <city>Austin</city>
+      <state>TX</state>
+      <latitude>30.414619</latitude>
+      <longitude>-97.777438</longitude>
+    </address>
+    <zestimate>
+      <amount currency="USD">382942</amount>
+      <last-updated>04/09/2013</last-updated>
+      <oneWeekChange deprecated="true"></oneWeekChange>
+      <valueChange duration="30" currency="USD">4774</valueChange>
+      <valuationRange>
+        <low currency="USD">329330</low>
+        <high currency="USD">436554</high>
+      </valuationRange>
+      <percentile>73</percentile>
+    </zestimate>
+    <rentzestimate>
+      <amount currency="USD">2505</amount>
+      <last-updated>04/01/2013</last-updated>
+      <oneWeekChange deprecated="true"></oneWeekChange>
+      <valueChange></valueChange>
+      <valuationRange>
+        <low currency="USD">1979</low>
+        <high currency="USD">3056</high>
+      </valuationRange>
+    </rentzestimate>
+    <localRealEstate>
+      <region id="10221" type="city" name="Austin">
+        <links>
+          <overview>http://www.zillow.com/local-info/TX-Austin/r_10221/</overview>
+          <forSaleByOwner>http://www.zillow.com/austin-tx/fsbo/</forSaleByOwner>
+          <forSale>http://www.zillow.com/austin-tx/</forSale>
+        </links>
+      </region>
+    </localRealEstate>
+    <regions>
+      <zipcode-id>92668</zipcode-id>
+      <city-id>10221</city-id>
+      <county-id>1440</county-id>
+      <state-id>54</state-id>
+    </regions>
+  </response>
+</Zestimate:zestimate>
+<!-- H:003  T:6ms  S:1133  R:Wed Apr 10 10:53:47 PDT 2013  B:3.0.189437.20130408124808855-comp_rel_b.189437.20130408124954685-comp_rel_b -->


### PR DESCRIPTION
Zillow typically returns a rentzestimate in this format:

``` xml
<rentzestimate>
  <amount currency="USD">2505</amount>
  <last-updated>04/01/2013</last-updated>
  <oneWeekChange deprecated="true"></oneWeekChange>
  <valueChange duration="30">50</valueChange>
  <valuationRange>
    <low currency="USD">1979</low>
    <high currency="USD">3056</high>
  </valuationRange>
</rentzestimate>
```

However, sometimes `<valueChange>` doesn't have a `duration` attribute.  

``` xml
<valueChange></valueChange>
```

This was causing Rubillow to throw an error like the following for me:

> NoMethodError: undefined method `value' for nil:NilClass - Zestimateable#extract_zestimate:71

The offending line in Rubillow looked like this:

``` ruby
:value_duration => xml.xpath('//rentzestimate/valueChange').attr('duration').value.chomp
```

The duration attribute is nil, so this raised an error.  Fixed it with this:

``` ruby
:value_duration => xml.xpath('//rentzestimate').first.xpath("//valueChange").first.attr("duration").chomp
```

I added a test to verify that this fixes the issue, and also **bumped the version number to 0.0.6.**  Since this is a patch, I think [SemVer](http://semver.org/) would require a new version number.

**P.S.** Why are we calling [String#chomp](http://ruby-doc.org/core-2.0/String.html#chomp-method) on the end here?  It was already there so I left it in, but it seems unnecessary to me.
