### PR TITLE
No longer call #chomp on the end of value duration

### DIFF
--- a/lib/rubillow/models/zestimateable.rb
+++ b/lib/rubillow/models/zestimateable.rb
@@ -67,7 +67,7 @@ module Rubillow
             :price => xml.xpath('//rentzestimate/amount').first.text,
             :last_updated => xml.xpath('//rentzestimate/last-updated').first.text,
             :value_change => xml.xpath('//rentzestimate/valueChange').first.text,
-            :value_duration => xml.xpath('//rentzestimate').first.xpath("//valueChange").first.attr("duration").chomp,
+            :value_duration => xml.xpath('//rentzestimate').first.xpath("//valueChange").first.attr("duration"),
             :valuation_range => {
               :low => xml.xpath('//rentzestimate/valuationRange/low').first.text,
               :high => xml.xpath('//rentzestimate/valuationRange/high').first.text


### PR DESCRIPTION
According to the ruby documentation, #chomp removes new line characters
such as \r\n or \n from the end of a string.  I don't see any reason to
expect these to be in the duration attribute, and it causes this error
when duration is not present:

> NoMethodError: undefined method `chomp' for nil:NilClass
