### PR TITLE
Fix for region_children query returning an empty string for neighborhoods.

### DIFF
--- a/lib/rubillow/models/region.rb
+++ b/lib/rubillow/models/region.rb
@@ -4,37 +4,37 @@ module Rubillow
     class Region < Base
       # @return [String] region id.
       attr_accessor :id
-      
+
       # @return [String] state.
       attr_accessor :state
-      
+
       # @return [String] city.
       attr_accessor :city
-      
+
       # @return [String] neighborhood.
       attr_accessor :neighborhood
-      
+
       # @return [String] latitude.
       attr_accessor :latitude
-      
+
       # @return [String] longitude.
       attr_accessor :longitude
-      
+
       # @return [String] ZMM rate URL.
       attr_accessor :zmmrateurl
-      
+
       protected
-      
+
       # @private
       def parse
         super
-        
+
         return if !success?
-        
+
         @id = @parser.xpath('//id').first.text
         @state = @parser.xpath('//state').text
         @city = @parser.xpath('//city').text
-        @neighborhood = @parser.xpath('//neighborhood').text
+        @neighborhood = @parser.xpath('//name').text
         @latitude = @parser.xpath('//latitude').text
         @longitude = @parser.xpath('//longitude').text
         @zmmrateurl = @parser.xpath('//zmmrateurl').text

--- a/spec/rubillow/models/region_children_spec.rb
+++ b/spec/rubillow/models/region_children_spec.rb
@@ -3,9 +3,10 @@ require "spec_helper"
 describe Rubillow::Models::RegionChildren do
   it "populates the data" do
     data = Rubillow::Models::RegionChildren.new(get_xml('get_region_children.xml'))
-    
+
     data.region.id.should == "16037"
     data.regions.count.should == 107
     data.regions[0].id.should == "343997"
+    data.regions[0].neighborhood.should == "Alki"
   end
 end


### PR DESCRIPTION
Revised region model to return the names of the neighborhoods in a specified market instead of just an empty string when running a region_children query.
