### PR TITLE
Allow for Nokogiri versions > 1.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubillow (0.0.8)
-      nokogiri (~> 1.5.0)
+      nokogiri (>= 1.5.0)
 
 GEM
   remote: http://rubygems.org/
@@ -17,8 +17,10 @@ GEM
       thor
     diff-lcs (1.2.1)
     mime-types (1.21)
+    mini_portile (0.6.2)
     multi_json (1.6.1)
-    nokogiri (1.5.9)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     rake (10.0.3)
     rest-client (1.6.7)
       mime-types (>= 1.16)

--- a/rubillow.gemspec
+++ b/rubillow.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "nokogiri", "~> 1.5.0"
+  s.add_dependency "nokogiri", ">= 1.5.0"
 
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 2.12"


### PR DESCRIPTION
It doesn't really make sense to lock down the host app to Nokogiri 1.5.0 when nothing in the gem requires that specific version.
