### PR TITLE
Added configuration option 'use_ssl'.

### DIFF
--- a/lib/rubillow/configuration.rb
+++ b/lib/rubillow/configuration.rb
@@ -7,6 +7,9 @@ module Rubillow
     # @return [Integer] HTTP port (defaults to +80+)
     attr_accessor :port
     
+    # @return [Boolean] Use HTTPS (defaults to +false+)
+    attr_accessor :use_ssl
+
     # @return [String] relative service path (defaults to +webservice/+)
     attr_accessor :path
     
@@ -22,7 +25,8 @@ module Rubillow
     # @private
     def initialize
       self.host              = "www.zillow.com"
-      self.port              = 80
+      self.port              = 443
+      self.use_ssl           = true
       self.path              = "webservice/"
       self.http_open_timeout = 2
       self.http_read_timeout = 2

--- a/lib/rubillow/request.rb
+++ b/lib/rubillow/request.rb
@@ -34,6 +34,7 @@ module Rubillow
     def self.request
       http = Net::HTTP.new(Rubillow.configuration.host, Rubillow.configuration.port)
       
+      http.use_ssl    = Rubillow.configuration.use_ssl
       http.open_timeout = Rubillow.configuration.http_open_timeout
       http.read_timeout = Rubillow.configuration.http_read_timeout
       http

--- a/spec/rubillow/configuration_spec.rb
+++ b/spec/rubillow/configuration_spec.rb
@@ -2,7 +2,8 @@ require "spec_helper"
 
 describe Rubillow::Configuration do
   it { should have_configuration_option(:host).default("www.zillow.com") }
-  it { should have_configuration_option(:port).default(80) }
+  it { should have_configuration_option(:port).default(443) }
+  it { should have_configuration_option(:use_ssl).default(true) }
   it { should have_configuration_option(:path).default("webservice/") }
   it { should have_configuration_option(:zwsid).default(nil) }
   it { should have_configuration_option(:http_open_timeout).default(2) }

--- a/spec/rubillow/request_spec.rb
+++ b/spec/rubillow/request_spec.rb
@@ -53,6 +53,7 @@ describe Rubillow::Request, ".request" do
   it "connects to configured host and port" do
     Rubillow::Request.request.address.should == Rubillow.configuration.host
     Rubillow::Request.request.port.should    == Rubillow.configuration.port
+    Rubillow::Request.request.use_ssl?.should == Rubillow.configuration.use_ssl
   end
 
   it "sets configured open and read timeouts" do


### PR DESCRIPTION
Zillow API now appears to force HTTPS. I added ability to configure use of HTTPS and updated the defaults to now use it by default.